### PR TITLE
Evictions test case and small modification

### DIFF
--- a/pkg/rescheduler/evictions/evictions_test.go
+++ b/pkg/rescheduler/evictions/evictions_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package evictions
+
+import (
+	"github.com/aveshagarwal/rescheduler/test"
+	"k8s.io/apimachinery/pkg/runtime"
+	core "k8s.io/client-go/testing"
+	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset/fake"
+	"testing"
+)
+
+func TestEvictPod(t *testing.T) {
+	n1 := test.BuildTestNode("node1", 1000, 2000, 9)
+	p1 := test.BuildTestPod("p1", 400, 0, n1.Name)
+	fakeClient := &fake.Clientset{}
+	fakeClient.Fake.AddReactor("list", "pods", func(action core.Action) (bool, runtime.Object, error) {
+		return true, &v1.PodList{Items: []v1.Pod{*p1}}, nil
+	})
+	evicted, _ := EvictPod(fakeClient, p1, "v1")
+	if !evicted {
+		t.Errorf("Expected %v pod to be evicted", p1.Name)
+	}
+
+}


### PR DESCRIPTION
@aveshagarwal I believe this completes the unit tests. We have 3 more files without unit tests  which are client.go, policyconfig.go, rescheduler.go and I think none of them needs unit tests. Please let me know what you think. I think, we can add a travis.yaml file and code coverage badge from covers.io or someother code coverage tool.