### PR TITLE
Small refactor to accomodate descheduling only evictable pods

### DIFF
--- a/pkg/descheduler/strategies/lownodeutilization.go
+++ b/pkg/descheduler/strategies/lownodeutilization.go
@@ -284,12 +284,8 @@ func NodeUtilization(node *v1.Node, pods []*v1.Pod) (api.ResourceThresholds, []*
 	gPods := []*v1.Pod{}
 	totalReqs := map[v1.ResourceName]resource.Quantity{}
 	for _, pod := range pods {
-		sr, err := podutil.CreatorRef(pod)
-		if err != nil {
-			sr = nil
-		}
-
-		if podutil.IsMirrorPod(pod) || podutil.IsPodWithLocalStorage(pod) || sr == nil || podutil.IsDaemonsetPod(sr) || podutil.IsCriticalPod(pod) {
+		// We need to compute the usage of nonRemovablePods unless it is a best effort pod. So, cannot use podutil.ListEvictablePodsOnNode
+		if !podutil.IsEvictable(pod) {
 			nonRemovablePods = append(nonRemovablePods, pod)
 			if podutil.IsBestEffortPod(pod) {
 				continue

--- a/pkg/descheduler/strategies/pod_antiaffinity.go
+++ b/pkg/descheduler/strategies/pod_antiaffinity.go
@@ -44,7 +44,7 @@ func removePodsWithAffinityRules(client clientset.Interface, policyGroupVersion 
 	podsEvicted := 0
 	for _, node := range nodes {
 		glog.V(1).Infof("Processing node: %#v\n", node.Name)
-		pods, err := podutil.ListPodsOnANode(client, node)
+		pods, err := podutil.ListEvictablePodsOnNode(client, node)
 		if err != nil {
 			return 0
 		}

--- a/pkg/descheduler/strategies/pod_antiaffinity_test.go
+++ b/pkg/descheduler/strategies/pod_antiaffinity_test.go
@@ -19,7 +19,6 @@ package strategies
 import (
 	"testing"
 
-	"fmt"
 	"github.com/kubernetes-incubator/descheduler/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -34,6 +33,9 @@ func TestPodAntiAffinity(t *testing.T) {
 	p2 := test.BuildTestPod("p2", 100, 0, node.Name)
 	p3 := test.BuildTestPod("p3", 100, 0, node.Name)
 	p3.Labels = map[string]string{"foo": "bar"}
+	p1.Annotations = test.GetNormalPodAnnotation()
+	p2.Annotations = test.GetNormalPodAnnotation()
+	p3.Annotations = test.GetNormalPodAnnotation()
 	p1.Spec.Affinity = &v1.Affinity{
 		PodAntiAffinity: &v1.PodAntiAffinity{
 			RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
@@ -80,7 +82,6 @@ func TestPodAntiAffinity(t *testing.T) {
 	expectedEvictedPodCount := 1
 	podsEvicted := removePodsWithAffinityRules(fakeClient, "v1", []*v1.Node{node}, false)
 	if podsEvicted != expectedEvictedPodCount {
-		fmt.Println(podsEvicted)
 		t.Errorf("Unexpected no of pods evicted")
 	}
 }


### PR DESCRIPTION
cc @aveshagarwal This is to ensure that all strategies will take into account only evictable pods. 

Fixes #48