### PR TITLE
Fix node lister by allowing its reflector to have enough time so that listing works.

### DIFF
--- a/pkg/descheduler/node/node.go
+++ b/pkg/descheduler/node/node.go
@@ -83,6 +83,9 @@ func GetNodeLister(client clientset.Interface, stopChannel <-chan struct{}) core
 	reflector := cache.NewReflector(listWatcher, &v1.Node{}, store, time.Hour)
 	reflector.RunUntil(stopChannel)
 
+	// To give some time so that listing works, chosen randomly
+	time.Sleep(100 * time.Millisecond)
+
 	return nodeLister
 }
 


### PR DESCRIPTION
Currently time duration is chosen randomly.