### PR TITLE
Introducing caching for serialized reference

### DIFF
--- a/pkg/descheduler/pod/pods.go
+++ b/pkg/descheduler/pod/pods.go
@@ -27,6 +27,13 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/types"
 )
 
+// Map to hold pod Name to serialized reference.
+type PodRefMap map[string]*v1.SerializedReference
+
+// A global variable to hold pod Name to serialized reference.
+// TODO: Make this metadata accessible across all strategies. Some items that could go in include podlist on node etc.
+var NewPodRefMap = PodRefMap{}
+
 // IsEvictable checks if a pod is evictable or not.
 func IsEvictable(pod *v1.Pod) bool {
 	sr, err := CreatorRef(pod)
@@ -36,6 +43,7 @@ func IsEvictable(pod *v1.Pod) bool {
 	if IsMirrorPod(pod) || IsPodWithLocalStorage(pod) || sr == nil || IsDaemonsetPod(sr) || IsCriticalPod(pod) {
 		return false
 	}
+	NewPodRefMap[pod.Name] = sr
 	return true
 }
 

--- a/pkg/descheduler/strategies/duplicates.go
+++ b/pkg/descheduler/strategies/duplicates.go
@@ -81,9 +81,15 @@ func ListDuplicatePodsOnANode(client clientset.Interface, node *v1.Node) Duplica
 func FindDuplicatePods(pods []*v1.Pod) DuplicatePodsMap {
 	dpm := DuplicatePodsMap{}
 	for _, pod := range pods {
-		// Ignoring the error here as in the ListDuplicatePodsOnNode function we call ListEvictablePodsOnNode
-		// which checks for error.
-		sr, _ := podutil.CreatorRef(pod)
+		var sr *v1.SerializedReference
+		var ok bool
+		// Check if sr exists in the map
+		if sr, ok = podutil.NewPodRefMap[pod.Name]; !ok {
+			// Ignoring the error here as in the ListDuplicatePodsOnNode function we call ListEvictablePodsOnNode
+			// which checks for error.
+			// Fallback to computing from CreatorRef.
+			sr, _ = podutil.CreatorRef(pod)
+		}
 		s := strings.Join([]string{sr.Reference.Kind, sr.Reference.Namespace, sr.Reference.Name}, "/")
 		dpm[s] = append(dpm[s], pod)
 	}


### PR DESCRIPTION
/cc @aveshagarwal - While working on duplicate pod strategy, I realized we need benchmarking of existing strategies. After looking at the call graphs it seems we are spending lot of time on serialization of json in CreatorRef function. So, I cached that in a map. This reduced the benchmarking time from 86sec to 56sec. 

Attaching the call graphs for reference.

Before: 
[cpu5.pdf](https://github.com/kubernetes-incubator/descheduler/files/1527815/cpu5.pdf)

After:
[cpu6.pdf](https://github.com/kubernetes-incubator/descheduler/files/1527817/cpu6.pdf)

