### PR TITLE
Make GPU requested pods not evictable by descheduler

### DIFF
--- a/pkg/descheduler/pod/pods_test.go
+++ b/pkg/descheduler/pod/pods_test.go
@@ -33,6 +33,9 @@ func TestPodTypes(t *testing.T) {
 	p3 := test.BuildTestPod("p3", 400, 0, n1.Name)
 	p4 := test.BuildTestPod("p4", 400, 0, n1.Name)
 	p5 := test.BuildTestPod("p5", 400, 0, n1.Name)
+	p6 := test.BuildTestPod("p6", 400, 0, n1.Name)
+	p6.Spec.Containers[0].Resources.Requests[v1.ResourceNvidiaGPU] = *resource.NewMilliQuantity(3, resource.DecimalSI)
+	p6.Annotations = test.GetNormalPodAnnotation()
 
 	p1.Annotations = test.GetReplicaSetAnnotation()
 	// The following 4 pods won't get evicted.
@@ -71,6 +74,9 @@ func TestPodTypes(t *testing.T) {
 	sr, _ = CreatorRef(p1)
 	if IsDaemonsetPod(sr) || IsPodWithLocalStorage(p1) || IsCriticalPod(p1) || IsMirrorPod(p1) {
 		t.Errorf("Expected p1 to be a normal pod.")
+	}
+	if !IsLatencySensitivePod(p6) {
+		t.Errorf("Expected p6 to be latency sensitive pod")
 	}
 
 }

--- a/test/test_utils.go
+++ b/test/test_utils.go
@@ -24,9 +24,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/v1"
 )
 
-// TODO:@ravisantoshgudimetla. As of now building some test pods here. This needs to
-// move to utils after refactor.
-// buildTestPod creates a test pod with given parameters.
+// BuildTestPod creates a test pod with given parameters.
 func BuildTestPod(name string, cpu int64, memory int64, nodeName string) *v1.Pod {
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
/cc @aveshagarwal - Partially fixes #8.

Added function for checking latency sensitive pods. As of now, handles GPUs after rebase to 1.8 we should be able to handle other high value resources.