### PR TITLE
Descheduler should not run when cluster size is 1

### DIFF
--- a/pkg/descheduler/descheduler.go
+++ b/pkg/descheduler/descheduler.go
@@ -55,8 +55,8 @@ func Run(rs *options.DeschedulerServer) error {
 		return err
 	}
 
-	if len(nodes) == 0 {
-		glog.V(1).Infof("node list is empty")
+	if len(nodes) <= 1 {
+		glog.V(1).Infof("The cluster size is 0 or 1 meaning eviction causes service disruption or degradation. So aborting..")
 		return nil
 	}
 


### PR DESCRIPTION
This ensures that no strategy is run in first place when the cluster size is 1.

/cc @aveshagarwal @containscafeine 