### PR TITLE
Universal Docker build

### DIFF
--- a/dockerbuild/Dockerfile
+++ b/dockerbuild/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.9
+
+WORKDIR /golang
+ENV GOPATH /golang
+WORKDIR /golang/src/github.com
+
+RUN    git clone https://github.com/kubernetes-incubator/descheduler.git kubernetes-incubator/descheduler \
+    && make -C kubernetes-incubator/descheduler \
+    && cp kubernetes-incubator/descheduler/_output/bin/descheduler /bin/descheduler \
+    && rm -rf kubernetes-incubator/descheduler
+
+CMD ["/bin/descheduler", "--help"]


### PR DESCRIPTION
I'm opening this PR to start a discussion.
This project currently supports building a Docker image, but it only works on linux distribution compatible with Docker. This is because the Go  binaries are compiled on the host machine and then moved to docker.

For example if you run `make` and `make image` on a Mac, then try to run the Docker image you get an error like this:

```
/bin/sh: /bin/descheduler: cannot execute binary file: Exec format error
```

I think a better approach would be to compile the Go code directly in the docker container.

I've added the Dockerfile which I use to build the Descheduler. This is just an example. If we were to integrate with this project we should probably use a `COPY` command rather than cloning from git.

Let me know your thoughts and I'd happy to tweak my Dockerfile to make it fit this project