### PR TITLE
Evict pods which has no owner references.

### DIFF
--- a/pkg/descheduler/pod/pods.go
+++ b/pkg/descheduler/pod/pods.go
@@ -54,7 +54,7 @@ func IsLatencySensitivePod(pod *v1.Pod) bool {
 // IsEvictable checks if a pod is evictable or not.
 func IsEvictable(pod *v1.Pod) bool {
 	ownerRefList := OwnerRef(pod)
-	if IsMirrorPod(pod) || IsPodWithLocalStorage(pod) || len(ownerRefList) == 0 || IsDaemonsetPod(ownerRefList) || IsCriticalPod(pod) {
+	if IsMirrorPod(pod) || IsPodWithLocalStorage(pod) || IsDaemonsetPod(ownerRefList) || IsCriticalPod(pod) {
 		return false
 	}
 	return true

--- a/pkg/descheduler/pod/pods_test.go
+++ b/pkg/descheduler/pod/pods_test.go
@@ -35,7 +35,7 @@ func TestPodTypes(t *testing.T) {
 	p5 := test.BuildTestPod("p5", 400, 0, n1.Name)
 	p6 := test.BuildTestPod("p6", 400, 0, n1.Name)
 	p6.Spec.Containers[0].Resources.Requests[v1.ResourceNvidiaGPU] = *resource.NewMilliQuantity(3, resource.DecimalSI)
-
+	p7 := test.BuildTestPod("p7", 400, 0, n1.Name)
 	p6.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
 
 	p1.ObjectMeta.OwnerReferences = test.GetReplicaSetOwnerRefList()
@@ -80,5 +80,7 @@ func TestPodTypes(t *testing.T) {
 	if !IsLatencySensitivePod(p6) {
 		t.Errorf("Expected p6 to be latency sensitive pod")
 	}
-
+	if !IsEvictable(p7) {
+		t.Errorf("Expected p7 to be evictablePod")
+	}
 }


### PR DESCRIPTION
While working on e2e's, I realized that pods that have no owner references are not evictable. So, I removed the check for that and added a regression test.