### PR TITLE
Allow to override repository organization

### DIFF
--- a/hack/lib/init.sh
+++ b/hack/lib/init.sh
@@ -43,5 +43,5 @@ OS_ROOT="$( os::util::absolute_path "${init_source}" )"
 export OS_ROOT
 cd "${OS_ROOT}"
 
-PRJ_PREFIX="github.com/kubernetes-incubator/descheduler"
+PRJ_PREFIX="github.com/${REPO_ORG:-kubernetes-incubator}/descheduler"
 OS_OUTPUT_BINPATH="${OS_ROOT}/_output/bin"

--- a/hack/update-codecgen.sh
+++ b/hack/update-codecgen.sh
@@ -40,7 +40,7 @@ generated_files=($(
 
 # We only work for deps within this prefix.
 #my_prefix="k8s.io/kubernetes"
-my_prefix="github.com/kubernetes-incubator/descheduler"
+my_prefix="github.com/${REPO_ORG:-kubernetes-incubator}/descheduler"
 
 # Register function to be called on EXIT to remove codecgen
 # binary and also to touch the files that should be regenerated

--- a/test/run-e2e-tests.sh
+++ b/test/run-e2e-tests.sh
@@ -15,5 +15,6 @@
 #!/bin/bash
 
 # This just run e2e tests.
-go test github.com/kubernetes-incubator/descheduler/test/e2e/ -v
+PRJ_PREFIX="github.com/${REPO_ORG:-kubernetes-incubator}/descheduler"
+go test ${PRJ_PREFIX}/test/e2e/ -v
 

--- a/test/run-unit-tests.sh
+++ b/test/run-unit-tests.sh
@@ -15,5 +15,6 @@
 #!/bin/bash
 
 # This just run unit-tests. Ignoring the current directory so as to avoid running e2e tests.
-go test $(go list github.com/kubernetes-incubator/descheduler/... | grep -v github.com/kubernetes-incubator/descheduler/vendor/| grep -v github.com/kubernetes-incubator/descheduler/test/)
+PRJ_PREFIX="github.com/${REPO_ORG:-kubernetes-incubator}/descheduler"
+go test $(go list ${PRJ_PREFIX}/... | grep -v ${PRJ_PREFIX}/vendor/| grep -v ${PRJ_PREFIX}/test/)
 


### PR DESCRIPTION
Given the repository is build and about-to-be tested under openshift organization
we need to change the kubernetes-incubator into openshift. Yet, keeping both repos still in sync.