### PR TITLE
Fix readme to have empty value for critical pod annotation as required.

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ spec:
     metadata:
       name: descheduler-pod
       annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: "true"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:
         containers:
         - name: descheduler


### PR DESCRIPTION
@ravisantoshgudimetla @ingvagabund 

During testing, I noticed that value of critical pod annotation should be empty, so fixing readme.