### PR TITLE
Fix broken e2e tests

### DIFF
--- a/hack/e2e-gce/gcloud_create_cluster.sh
+++ b/hack/e2e-gce/gcloud_create_cluster.sh
@@ -10,7 +10,7 @@ master_uuid=$(uuid)
 node1_uuid=$(uuid)
 node2_uuid=$(uuid)
 kube_apiserver_port=6443
-kube_version=1.9.4
+kube_version=1.11.1
 
 DESCHEDULER_ROOT=$(dirname "${BASH_SOURCE}")/../../
 E2E_GCE_HOME=$DESCHEDULER_ROOT/hack/e2e-gce


### PR DESCRIPTION
As of now, e2es in CI are broken because of kubeadm not able to install 1.9.4 cluster. Bumping the testing kube cluster to 1.11.1.

Error msg in CI:

`Flag --skip-preflight-checks has been deprecated, it is now equivalent to --ignore-preflight-errors=all
this version of kubeadm only supports deploying clusters with the control plane version >= 1.10.0. Current version: v1.9.4`