### PR TITLE
Fix deprecated warning in CI

### DIFF
--- a/hack/e2e-gce/gcloud_create_cluster.sh
+++ b/hack/e2e-gce/gcloud_create_cluster.sh
@@ -39,7 +39,7 @@ generate_kubeadm_instance_files() {
 	master_public_ip=$(gcloud compute instances list | grep $master_uuid|awk '{print $5}')
 	node1_public_ip=$(gcloud compute instances list | grep $node1_uuid|awk '{print $5}')
 	node2_public_ip=$(gcloud compute instances list | grep $node2_uuid|awk '{print $5}')
-	echo "kubeadm init --kubernetes-version=${kube_version} --apiserver-advertise-address=${master_public_ip}" --skip-preflight-checks --pod-network-cidr=10.96.0.0/12 > $E2E_GCE_HOME/kubeadm_install.sh
+	echo "kubeadm init --kubernetes-version=${kube_version} --apiserver-advertise-address=${master_public_ip}" --ignore-preflight-errors=all --pod-network-cidr=10.96.0.0/12 > $E2E_GCE_HOME/kubeadm_install.sh
 }
 
 


### PR DESCRIPTION
I am seeing the following errors in CI continuously.

Flag --skip-preflight-checks has been deprecated, it is now equivalent to --ignore-preflight-errors=all

This should fix the behaviour.