### PR TITLE
Update the compatibility matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ This roadmap is not in any particular order.
 
 Descheduler  | supported Kubernetes version
 -------------|-----------------------------
-0.4          | 1.9+
+0.4+          | 1.9+
 0.1-0.3      | 1.7-1.8
 
 ## Note


### PR DESCRIPTION
Descheduler 0.4+ should work with kube 1.9+.

/cc @aveshagarwal 