### PR TITLE
Care about namespace when evaluating pods in the duplicate strategy

### DIFF
--- a/pkg/descheduler/strategies/duplicates.go
+++ b/pkg/descheduler/strategies/duplicates.go
@@ -50,19 +50,20 @@ func deleteDuplicatePods(client clientset.Interface, policyGroupVersion string, 
 		glog.V(1).Infof("Processing node: %#v", node.Name)
 		dpm := ListDuplicatePodsOnANode(client, node)
 		for creator, pods := range dpm {
-			if len(pods) > 1 {
-				glog.V(1).Infof("%#v", creator)
-				// i = 0 does not evict the first pod
-				for i := 1; i < len(pods); i++ {
-					if maxPodsToEvict > 0 && nodepodCount[node]+1 > maxPodsToEvict {
-						break
-					}
-					success, err := evictions.EvictPod(client, pods[i], policyGroupVersion, dryRun)
-					if !success {
-						glog.Infof("Error when evicting pod: %#v (%#v)", pods[i].Name, err)
-					} else {
-						nodepodCount[node]++
-						glog.V(1).Infof("Evicted pod: %#v (%#v)", pods[i].Name, err)
+			if len(pods) > 0 {
+				for i := 0; i < len(pods); i++ {
+					glog.V(5).Infof("Evaluating pod: %#v : %#v", creator, pods[i].Name)
+					if i > 0 {
+						if maxPodsToEvict > 0 && nodepodCount[node]+1 > maxPodsToEvict {
+							break
+						}
+						success, err := evictions.EvictPod(client, pods[i], policyGroupVersion, dryRun)
+						if !success {
+							glog.Infof("Error when evicting pod: %#v : %#v (%#v)", creator, pods[i].Name, err)
+						} else {
+							nodepodCount[node]++
+							glog.V(1).Infof("Evicted pod: %#v : %#v (%#v)", creator, pods[i].Name, err)
+						}
 					}
 				}
 			}

--- a/pkg/descheduler/strategies/duplicates.go
+++ b/pkg/descheduler/strategies/duplicates.go
@@ -90,8 +90,7 @@ func FindDuplicatePods(pods []*v1.Pod) DuplicatePodsMap {
 		// which checks for error.
 		ownerRefList := podutil.OwnerRef(pod)
 		for _, ownerRef := range ownerRefList {
-			// ownerRef doesn't need namespace since the assumption is owner needs to be in the same namespace.
-			s := strings.Join([]string{ownerRef.Kind, ownerRef.Name}, "/")
+			s := strings.Join([]string{ownerRef.Kind, pod.Namespace, ownerRef.Name}, "/")
 			dpm[s] = append(dpm[s], pod)
 		}
 	}

--- a/pkg/descheduler/strategies/duplicates.go
+++ b/pkg/descheduler/strategies/duplicates.go
@@ -53,6 +53,7 @@ func deleteDuplicatePods(client clientset.Interface, policyGroupVersion string, 
 			if len(pods) > 0 {
 				for i := 0; i < len(pods); i++ {
 					glog.V(5).Infof("Evaluating pod: %#v : %#v", creator, pods[i].Name)
+					//  i > 0 does not evict the first pod
 					if i > 0 {
 						if maxPodsToEvict > 0 && nodepodCount[node]+1 > maxPodsToEvict {
 							break


### PR DESCRIPTION
If two deployments in different namespaces have identical template hashes, the replicaset name is the same -- with the same name the **Remove Duplicates** strategy will erroneously evict pods.